### PR TITLE
[B2BORG-19] Block checkout if user's org is not active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- If a user's organization is "inactive" or "on hold", do not allow user to access checkout
+
 ## [0.4.0] - 2021-12-01
 
 ### Added


### PR DESCRIPTION
This PR treats users from "inactive" or "on hold" organizations the same as users who do not have the "can-checkout" permission. In other words a user's organization must be active for them to be able to place an order.

Linked in https://quotes--sandboxusdev.myvtex.com for testing