### PR TITLE
Improve display of payment methods

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
-CHANGELOG.md
 node/__mocks__/fixtures/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve display of allowed payment methods
+
 ## [0.6.1] - 2022-01-06
+
+### Added
+
+- SonarCloud PR integration
 
 ## [0.6.0] - 2022-01-04
 
 ### Removed
+
 - Custom Shipping section
 
 ### Added
+
 - `window.b2bCheckoutSettings` to provide context to the checkout customizations
+
 ## [0.5.0] - 2021-12-21
 
 ### Added
@@ -25,21 +36,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.4.0] - 2021-12-01
 
 ### Added
+
 - Filter payment methods to show only allowed ones by the Organization
+
 ## [0.3.0] - 2021-11-29
 
 ### Added
+
 - Don't allow buyer to checkout
 
 ## [0.2.0] - 2021-11-23
 
 ### Added
+
 - Loads Cost Center addresses at the checkout page
 
 ## [0.1.0] - 2021-11-12
 
 ### Added
+
 - PO Number option
+
 ## [0.0.1] - 2021-11-10
 
 ### Added

--- a/checkout-ui-custom/checkout6-custom.css
+++ b/checkout-ui-custom/checkout6-custom.css
@@ -21,11 +21,14 @@
 .client-profile-data a.link-box-edit,
 button.vtex-omnishipping-1-x-buttonEditAddress,
 button.vtex-omnishipping-1-x-buttonCreateAddress,
-.orderform-template-holder #payment-data .payment-group-item {
+.orderform-template-holder #payment-data .v-custom-payment-item-wrap {
   display: none;
 }
 body.change-profile .client-profile-data a.link-box-edit,
 body.edit-shipping button.vtex-omnishipping-1-x-buttonEditAddress,
-body.add-shipping button.vtex-omnishipping-1-x-buttonCreateAddress {
+body.add-shipping button.vtex-omnishipping-1-x-buttonCreateAddress,
+.orderform-template-holder
+  #payment-data
+  .v-custom-payment-item-wrap.b2b-allowed-payment {
   display: block;
 }

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -95,7 +95,7 @@
     const activeOptionText = activeOption ? activeOption.innerText.trim() : ''
     let firstOption = null
 
-    const idsToShow = []
+    // const idsToShow = []
 
     if (
       permissions &&
@@ -114,19 +114,9 @@
             firstOption = obj
           }
 
-          idsToShow.push(obj.id)
+          obj.parentElement.classList.add('b2b-allowed-payment')
         }
       })
-    }
-
-    if (!$('style#b2bPayments').size() && idsToShow.length) {
-      $(
-        `<style id="b2bPayments">${idsToShow
-          .map(function (id) {
-            return `#payment-data .payment-group-item#${id}{display:flex;}`
-          })
-          .join('')}</style>`
-      ).appendTo('body')
     }
 
     if (

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -95,8 +95,6 @@
     const activeOptionText = activeOption ? activeOption.innerText.trim() : ''
     let firstOption = null
 
-    // const idsToShow = []
-
     if (
       permissions &&
       permissions.paymentTerms &&


### PR DESCRIPTION
This PR employs a slightly different usage of CSS to show/hide the appropriate payment methods in the B2B checkout.
New version is linked in https://quotes--sandboxusdev.myvtex.com

Before:
<img width="780" alt="b2b-checkout-before" src="https://user-images.githubusercontent.com/6306265/151066769-3b8e7b9e-fcab-4ee3-b859-1d9880e77969.png">

After:
<img width="759" alt="b2b-checkout-after" src="https://user-images.githubusercontent.com/6306265/151066216-da094f1b-0b54-4619-aef9-a5e3fb9f8edf.png">
