### PR TITLE
B2BCHCKOUT-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added a new feature to check if the order form has a custom data property ("b2b-quotes-graphql") from quotes and then the items in the cart will be locked by .item-disabled css class which disables the pointer events from mouse/touch.
+
 ## [0.6.2] - 2022-01-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+
 - Added a new feature to check if the order form has a custom data property ("b2b-quotes-graphql") from quotes and then the items in the cart will be locked by .item-disabled css class which disables the pointer events from mouse/touch.
 
 ## [0.6.2] - 2022-01-26

--- a/checkout-ui-custom/checkout6-custom.css
+++ b/checkout-ui-custom/checkout6-custom.css
@@ -32,3 +32,8 @@ body.add-shipping button.vtex-omnishipping-1-x-buttonCreateAddress,
   .v-custom-payment-item-wrap.b2b-allowed-payment {
   display: block;
 }
+
+.item-disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -157,6 +157,52 @@
     window.b2bCheckoutSettings = settings
   }
 
+  let checkQuotesCounter = 0
+  let checkQuotesInterval = null
+
+  const watchQuotes = function () {
+    if (checkQuotesInterval) {
+      clearInterval(checkQuotesInterval)
+    }
+
+    checkQuotesInterval = setInterval(function () {
+      checkQuotes()
+      if (checkQuotesCounter >= 10000) {
+        clearInterval(checkQuotesInterval)
+      }
+    }, 400)
+  }
+
+  const checkQuotes = function () {
+    if (window.vtexjs && window.vtexjs.checkout.orderForm.customData) {
+      const { customData } = window.vtexjs.checkout.orderForm
+
+      if (customData.customApps) {
+        const index = customData.customApps.findIndex(function (item) {
+          return item.id === 'b2b-quotes-graphql'
+        })
+
+        if (index !== -1 && customData.customApps[index].fields.quoteId) {
+          const selectorsToLock = [
+            'td.quantity',
+            'a.manualprice-link-remove',
+            'span.new-product-price',
+            'td.item-remove',
+          ]
+
+          selectorsToLock.forEach(function (selector) {
+            if (!$(selector).hasClass('item-disabled')) {
+              checkQuotesCounter = 0
+              $(selector).addClass('item-disabled')
+            } else {
+              checkQuotesCounter++
+            }
+          })
+        }
+      }
+    }
+  }
+
   const fetchSettings = function () {
     const rootPath =
       window.vtex.renderRuntime.rootPath !== undefined
@@ -190,6 +236,9 @@
       }
     }
   }, 500)
+
+  checkQuotes()
+  watchQuotes()
 
   window.addEventListener('hashchange', function () {
     const message = window.sessionStorage.getItem('message')


### PR DESCRIPTION
Added a new feature to check if the order form has a custom data property ("b2b-quotes-graphql") from quotes and then the items in the cart will be locked by .item-disabled css class which disables the pointer events from mouse/touch.

## What problem is this solving?

According to the [B2BCHCKOUT-11](https://vtex-dev.atlassian.net/browse/B2BCHCKOUT-11), when the cart comes from a quote, it must be locked, so, the solution was provided by a JS & css locking the elements from the cart.

## How to test it ?

This feature has been linked on this URL [https://artur--b2bstoreqa.myvtex.com/](https://artur--b2bstoreqa.myvtex.com/).

1) Access the url: [https://artur--b2bstoreqa.myvtex.com](https://artur--b2bstoreqa.myvtex.com)
2) Go to this url: [https://artur--b2bstoreqa.myvtex.com/b2b-quotes](https://artur--b2bstoreqa.myvtex.com/b2b-quotes)
3) Use this credential: kevin.yee@vtex.com / Vtex1234
4) The page will be reloaded and then you can access the list of quotes
5) Access some quote and than click at "Use Quote" button at the bottom of page
6) You will redirected to the checkout page, so you will see that some actions from cart should be locked
