### PR TITLE
[B2BCHCKOUT-13] Fix display of payment terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct payment methods will be displayed regardless of whether payment terms are shown as tabs or accordions, and regardless of whether this app's checkout JS runs before or after checkout-ui-custom's
+
 ## [0.6.2] - 2022-01-26
 
 ### Fixed

--- a/checkout-ui-custom/checkout6-custom.css
+++ b/checkout-ui-custom/checkout6-custom.css
@@ -21,17 +21,15 @@
 .client-profile-data a.link-box-edit,
 button.vtex-omnishipping-1-x-buttonEditAddress,
 button.vtex-omnishipping-1-x-buttonCreateAddress,
-/* .orderform-template-holder #payment-data .v-custom-payment-item-wrap  */
 .orderform-template-holder #payment-data .payment-group-item {
   display: none;
 }
 body.change-profile .client-profile-data a.link-box-edit,
 body.edit-shipping button.vtex-omnishipping-1-x-buttonEditAddress,
 body.add-shipping button.vtex-omnishipping-1-x-buttonCreateAddress,
-.orderform-template-holder #payment-data .payment-group-item[data-b2b-allowed="true"]
-/* .orderform-template-holder
+.orderform-template-holder
   #payment-data
-  .v-custom-payment-item-wrap.b2b-allowed-payment-container */ {
+  .payment-group-item[data-b2b-allowed='true'] {
   display: block;
 }
 

--- a/checkout-ui-custom/checkout6-custom.css
+++ b/checkout-ui-custom/checkout6-custom.css
@@ -21,14 +21,23 @@
 .client-profile-data a.link-box-edit,
 button.vtex-omnishipping-1-x-buttonEditAddress,
 button.vtex-omnishipping-1-x-buttonCreateAddress,
-.orderform-template-holder #payment-data .v-custom-payment-item-wrap {
+/* .orderform-template-holder #payment-data .v-custom-payment-item-wrap  */
+.orderform-template-holder #payment-data .payment-group-item {
   display: none;
 }
 body.change-profile .client-profile-data a.link-box-edit,
 body.edit-shipping button.vtex-omnishipping-1-x-buttonEditAddress,
 body.add-shipping button.vtex-omnishipping-1-x-buttonCreateAddress,
-.orderform-template-holder
+.orderform-template-holder #payment-data .payment-group-item[data-b2b-allowed="true"]
+/* .orderform-template-holder
   #payment-data
-  .v-custom-payment-item-wrap.b2b-allowed-payment {
+  .v-custom-payment-item-wrap.b2b-allowed-payment-container */ {
   display: block;
+}
+
+.v-custom-payment-item-wrap {
+  border: none !important;
+}
+.v-custom-payment-item-wrap.active {
+  border: 1px solid !important;
 }

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -116,8 +116,6 @@
         }
 
         obj.setAttribute('data-b2b-allowed', 'true')
-        // obj.classList.add('b2b-allowed-payment')
-        // obj.parentElement.classList.add('b2b-allowed-payment-container')
       })
     }
 

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -106,14 +106,18 @@
         if (
           permissions.paymentTerms.findIndex(function (pmt) {
             return pmt.name === currOption
-          }) !== -1
+          }) === -1
         ) {
-          if (firstOption === null) {
-            firstOption = obj
-          }
-
-          obj.parentElement.classList.add('b2b-allowed-payment')
+          return
         }
+
+        if (firstOption === null) {
+          firstOption = obj
+        }
+
+        obj.setAttribute('data-b2b-allowed', 'true')
+        // obj.classList.add('b2b-allowed-payment')
+        // obj.parentElement.classList.add('b2b-allowed-payment-container')
       })
     }
 


### PR DESCRIPTION
The previous PR https://github.com/vtex-apps/b2b-checkout-settings/pull/8 had the unintended effect of making the checkout payment method filtering only work when: 
- the Checkout UI Custom "show payment methods as accordions" option was selected, and
- the B2B Checkout Settings JS was injected AFTER the Checkout UI Custom JS

Since we have no direct control over the order in which multiple checkout JS apps inject their JS, this PR aims to make the feature work regardless of which layout option is used, and which order JS is injected in.

This new version is linked in https://arthur--b2bstoreqa.myvtex.com

This is what it looks like: 

TABBED
<img width="423" alt="payment-tabbed" src="https://user-images.githubusercontent.com/6306265/152427426-04c9c5cc-d371-48e2-82bd-463ba00eb504.png">

ACCORDION
<img width="426" alt="payment-accordion" src="https://user-images.githubusercontent.com/6306265/152427441-3d8fea0d-5339-4826-8970-0cf6718cca30.png">

For the accordion formatting, note that there is still some weird extra spacing where the disabled payment methods are, but we may need to live with that. I was at least able to remove the borders around the hidden payment options using CSS.