### PR TITLE
Fix graphql sender version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Update version number of sender app when performing graphQL queries
+- Additional null checking in checkout6-custom.js
+
 ## [1.0.0] - 2022-02-22
 
 ### Added

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -203,7 +203,7 @@
   }
 
   const checkQuotes = function () {
- if (
+    if (
       window.vtexjs &&
       window.vtexjs.checkout &&
       window.vtexjs.checkout.orderForm &&

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -203,8 +203,9 @@
   }
 
   const checkQuotes = function () {
-    if (
+ if (
       window.vtexjs &&
+      window.vtexjs.checkout &&
       window.vtexjs.checkout.orderForm &&
       window.vtexjs.checkout.orderForm.customData
     ) {

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -203,7 +203,11 @@
   }
 
   const checkQuotes = function () {
-    if (window.vtexjs && window.vtexjs.checkout.orderForm.customData) {
+    if (
+      window.vtexjs &&
+      window.vtexjs.checkout.orderForm &&
+      window.vtexjs.checkout.orderForm.customData
+    ) {
       const { customData } = window.vtexjs.checkout.orderForm
 
       if (customData.customApps) {

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -151,7 +151,7 @@ export const resolvers = {
             {
               persistedQuery: {
                 provider: 'vtex.storefront-permissions@1.x',
-                sender: 'vtex.b2b-checkout-settings@0.x',
+                sender: 'vtex.b2b-checkout-settings@1.x',
               },
             }
           )
@@ -201,7 +201,7 @@ export const resolvers = {
               {
                 persistedQuery: {
                   provider: 'vtex.b2b-organizations-graphql@0.x',
-                  sender: 'vtex.b2b-checkout-settings@0.x',
+                  sender: 'vtex.b2b-checkout-settings@1.x',
                 },
               }
             )
@@ -253,7 +253,7 @@ export const resolvers = {
               {
                 persistedQuery: {
                   provider: 'vtex.b2b-organizations-graphql@0.x',
-                  sender: 'vtex.b2b-checkout-settings@0.x',
+                  sender: 'vtex.b2b-checkout-settings@1.x',
                 },
               }
             )


### PR DESCRIPTION
When the new 1.x major of this app was released, the `checkUserPermission` graphQL query stopped working because the `sender` property was still set to `vtex.b2b-checkout-settings@0.x` instead of 1.x. This PR fixes the problem.

I also added an additional null check to checkout6-custom.js as I noticed a type error was sporadically being thrown in checkout.

New version linked here: https://b2bsuite--sandboxusdev.myvtex.com