### PR TITLE
[B2BCHCKOUT-12] Fix payment terms CSS (0.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Apply `!important` to CSS rules to ensure appropriate payment methods are hidden
+
 ## [0.8.0] - 2022-02-18
 
 ### Added

--- a/checkout-ui-custom/checkout6-custom.css
+++ b/checkout-ui-custom/checkout6-custom.css
@@ -22,7 +22,7 @@
 button.vtex-omnishipping-1-x-buttonEditAddress,
 button.vtex-omnishipping-1-x-buttonCreateAddress,
 .orderform-template-holder #payment-data .payment-group-item {
-  display: none;
+  display: none !important;
 }
 body.change-profile .client-profile-data a.link-box-edit,
 body.edit-shipping button.vtex-omnishipping-1-x-buttonEditAddress,
@@ -30,11 +30,11 @@ body.add-shipping button.vtex-omnishipping-1-x-buttonCreateAddress,
 .orderform-template-holder
   #payment-data
   .payment-group-item[data-b2b-allowed='true'] {
-  display: block;
+  display: block !important;
 }
 
 .btn-b2b-primary {
-    margin: 10px 0;
+  margin: 10px 0;
 }
 
 .item-disabled {


### PR DESCRIPTION
This is a simple PR that applies `!important` to the show/hide payment term CSS rules. This fixes an issue where CSS injected into checkout by checkout-ui-custom was overriding the b2b-checkout-settings CSS and causing disabled payment terms to be displayed to the user.

I will also open a PR for the 1.x major.

New version linked here: https://arthur--b2bstoreqa.myvtex.com/