### PR TITLE
Fixing documentation image links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
 - Updated README.md file with correct image links
 
 ## [1.0.3] - 2022-03-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Updated README.md file with correct image links
+
 ## [1.0.3] - 2022-03-22
 
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ Note that if you have [Storefront Permissions UI](https://developers.vtex.com/vt
 
 The **B2B Checkout Settings** app communicates with the **B2B Organizations** app and automatically lists the [Cost Center addresses](https://developers.vtex.com/vtex-developer-docs/docs/vtex-b2b-organizations#cost-center-details) associated with the user during checkout:
 
-| ![cost-center-details-addresses](https://raw.githubusercontent.com/vtex-apps/b2b-checkout-settings/documentation-update/docs/images/cost-center-details-addresses.png) | ![shipping](https://raw.githubusercontent.com/vtex-apps/b2b-checkout-settings/documentation-update/docs/images/shipping.png) |
+| ![cost-center-details-addresses](https://raw.githubusercontent.com/vtex-apps/b2b-checkout-settings/master/docs/images/cost-center-details-addresses.png) | ![shipping](https://raw.githubusercontent.com/vtex-apps/b2b-checkout-settings/master/docs/images/shipping.png) |
 |-|-|
 | **Cost Center Details** page, displaying two options of addresses associated with the cost center in question | Checkout page for an user associated with this organization and cost center |
 
@@ -64,7 +64,7 @@ Having a purchase order number allows B2B customers to pay for authorized purcha
 
 Using **B2B Checkout Settings**, it is possible to enable an optional **Reference or PO Number** field for customers to insert this information during the checkout.
 
-![purchase-order](https://raw.githubusercontent.com/vtex-apps/b2b-checkout-settings/documentation-update/docs/images/purchase-order.png)
+![purchase-order](https://raw.githubusercontent.com/vtex-apps/b2b-checkout-settings/master/docs/images/purchase-order.png)
 
 See the [Configuration](#configuration) section to understand how to enable or disable this button.
 
@@ -72,7 +72,7 @@ See the [Configuration](#configuration) section to understand how to enable or d
 
 To change app settings, in the VTEX Admin go to **Store Setup** > **B2B Checkout Settings**.
 
-![b2b-checkout-settings](https://raw.githubusercontent.com/vtex-apps/b2b-checkout-settings/documentation-update/docs/images/b2b-checkout-settings.png)
+![b2b-checkout-settings](https://raw.githubusercontent.com/vtex-apps/b2b-checkout-settings/master/docs/images/b2b-checkout-settings.png)
 
 You can use the toggle button to activate or deactivate the available settings:
 


### PR DESCRIPTION
The images in the documentation were broken after the PR was merged. This PR fixes their links.