### PR TITLE
[B2BORG-83] Add support for enabling Credit Card payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.1.0] - 2022-03-25
+### Added
 
+- Adjust checkout JS to support showing the `Credit card` payment method
+
+## [1.1.0] - 2022-03-25
 
 ### Added
 

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -157,8 +157,14 @@
       allOptions.forEach(function (obj) {
         const currOption = obj.innerText.trim()
 
+        const isCreditCard = currOption.indexOf('Credit card') === 0
+
         if (
           permissions.paymentTerms.findIndex(function (pmt) {
+            if (isCreditCard) {
+              return pmt.name === 'Credit card'
+            }
+
             return pmt.name === currOption
           }) === -1
         ) {
@@ -171,14 +177,14 @@
 
         obj.setAttribute('data-b2b-allowed', 'true')
       })
-    }
 
-    if (
-      permissions.paymentTerms.findIndex(function (pmt) {
-        return pmt.name === activeOptionText
-      }) === -1
-    ) {
-      $(firstOption).click()
+      if (
+        permissions.paymentTerms.findIndex(function (pmt) {
+          return pmt.name === activeOptionText
+        }) === -1
+      ) {
+        $(firstOption).click()
+      }
     }
   }
 

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -155,17 +155,17 @@
       permissions.paymentTerms.length
     ) {
       allOptions.forEach(function (obj) {
-        const currOption = obj.innerText.trim()
+        const currOption = obj.innerText.trim().toLowerCase()
 
-        const isCreditCard = currOption.indexOf('Credit card') === 0
+        const isCreditCard = currOption.indexOf('credit card') === 0
 
         if (
           permissions.paymentTerms.findIndex(function (pmt) {
             if (isCreditCard) {
-              return pmt.name === 'Credit card'
+              return pmt.name.toLowerCase() === 'credit card'
             }
 
-            return pmt.name === currOption
+            return pmt.name.toLowerCase() === currOption
           }) === -1
         ) {
           return

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -146,7 +146,11 @@
       '.orderform-template-holder #payment-data .payment-group-item.active'
     )
 
-    const activeOptionText = activeOption ? activeOption.innerText.trim() : ''
+    const activeOptionText = activeOption
+      ? activeOption.innerText.trim().toLowerCase()
+      : ''
+
+    const isCreditCardActive = activeOptionText.indexOf('credit card') === 0
     let firstOption = null
 
     if (
@@ -180,7 +184,11 @@
 
       if (
         permissions.paymentTerms.findIndex(function (pmt) {
-          return pmt.name === activeOptionText
+          if (isCreditCardActive) {
+            return pmt.name.toLowerCase() === 'credit card'
+          }
+
+          return pmt.name.toLowerCase() === activeOptionText
         }) === -1
       ) {
         $(firstOption).click()


### PR DESCRIPTION
Related to https://github.com/vtex-apps/b2b-organizations-graphql/pull/21

As we have decided to allow organizations to use the Credit Card payment method (if assigned to that particular org), this PR adds some logic to support this. The method we're using to find the payment methods that should be enabled needed to be adjusted because the `innerText` of the Credit Card selector has more text than just "Credit Card". Therefore instead of an exact comparison, the app now checks if the inner text STARTS with "Credit card". 

New version linked here: https://b2bsuite--sandboxusdev.myvtex.com