### PR TITLE
[B2BORDERS-7] Make sure marketingData is set when user goes to checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- If user does not have marketing data (organization and cost center IDs) set in their orderForm at time of checkout, set it
+
 ## [1.1.1] - 2022-03-25
 
 ### Added

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -215,6 +215,17 @@
     showPaymentOptions(settings)
   }
 
+  const applyMarketingData = function (organizationId, costCenterId) {
+    if (!organizationId || !costCenterId) return false
+
+    const marketingData = {
+      utmCampaign: organizationId,
+      utmMedium: costCenterId,
+    }
+
+    window.vtexjs.checkout.sendAttachment('marketingData', marketingData)
+  }
+
   const handleSettings = function () {
     if (settings.showPONumber === true) {
       buildPOField()
@@ -226,6 +237,17 @@
 
     if (settings.showQuoteButton) {
       buildCreateQuoteButton()
+    }
+
+    if (
+      window.vtexjs &&
+      window.vtexjs.checkout &&
+      window.vtexjs.checkout.orderForm &&
+      window.vtexjs.checkout.orderForm.marketingData &&
+      (!window.vtexjs.checkout.orderForm.marketingData.utmCampaign ||
+        !window.vtexjs.checkout.orderForm.marketingData.utmMedium)
+    ) {
+      applyMarketingData(settings.organizationId, settings.costCenterId)
     }
 
     window.b2bCheckoutSettings = settings

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -189,14 +189,17 @@ export const resolvers = {
         if (
           userSession?.namespaces?.['storefront-permissions']?.costcenter?.value
         ) {
+          settings.costCenterId =
+            userSession?.namespaces?.[
+              'storefront-permissions'
+            ]?.costcenter?.value
           const {
             data: { getCostCenterById },
           }: any = await graphQLServer
             .query(
               QUERIES.getAddresses,
               {
-                id: userSession.namespaces['storefront-permissions'].costcenter
-                  .value,
+                id: settings.costCenterId,
               },
               {
                 persistedQuery: {
@@ -241,14 +244,17 @@ export const resolvers = {
           userSession?.namespaces?.['storefront-permissions']?.organization
             ?.value
         ) {
+          settings.organizationId =
+            userSession?.namespaces?.[
+              'storefront-permissions'
+            ]?.organization?.value
           const {
             data: { getOrganizationById },
           }: any = await graphQLServer
             .query(
               QUERIES.getOrganizationDetails,
               {
-                id: userSession.namespaces['storefront-permissions']
-                  .organization.value,
+                id: settings.organizationId,
               },
               {
                 persistedQuery: {


### PR DESCRIPTION
A client noticed that an order was missing from their B2B Orders History page. This order had been placed using the "Order again" feature in My Account. Investigating the problem revealed that if a user does not have an `orderFormId` at the time of login, storefront-permissions is not able to set the marketingData in their orderForm. This is where we store the user's organization ID and cost center ID for the purposes of the shared order history feature.  

This PR adds a fallback check to checkout: if the user has no marketingData in their orderForm when they arrive at the checkout page, it will be added automatically. 

New version linked here: https://b2bsuite--sandboxusdev.myvtex.com

To test: clear your cookies or use an incognito window, log in as an org user, go to My Account > Orders and click "Order Again" for any order. In checkout, use the JS console to check your orderForm, and you should see that the marketingData section is populated (specifically utmCampaign and utmMedium).