### PR TITLE
Support intl payment method names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Use different method to show/hide appropriate payment methods to support internationalized payment method labels
+
 ## [1.1.2] - 2022-03-28
 
 ### Fixed

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -231,16 +231,18 @@ const CREDIT_CARDS = [
     }
 
     // Show payment options available
-    checkPayment = setInterval(function () {
-      if (
-        document.querySelectorAll(
-          '.orderform-template-holder #payment-data .payment-group-item'
-        ).length > 0
-      ) {
-        clearInterval(checkPayment)
-        showPaymentOptions(settings)
-      }
-    }, 500)
+    if (step.includes('payment')) {
+      checkPayment = setInterval(function () {
+        if (
+          document.querySelectorAll(
+            '.orderform-template-holder #payment-data .payment-group-item'
+          ).length > 0
+        ) {
+          clearInterval(checkPayment)
+          showPaymentOptions(settings)
+        }
+      }, 500)
+    }
   }
 
   const applyMarketingData = function (organizationId, costCenterId) {
@@ -396,5 +398,5 @@ const CREDIT_CARDS = [
     }
   }
 
-  window.addEventListener('hashchange', initialize())
+  $(window).on('hashchange', () => initialize())
 })()

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -1,6 +1,25 @@
 /* eslint-disable no-undef */
 /* eslint-disable no-console */
 /* eslint-disable func-names */
+const CREDIT_CARDS = [
+  'visa',
+  'mastercard',
+  'diners',
+  'american express',
+  'hipercard',
+  'discover',
+  'aura',
+  'elo',
+  'banricompras',
+  'jcb',
+  'cabal',
+  'nativa',
+  'naranja',
+  'nevada',
+  'shopping',
+  'credz',
+]
+
 !(function () {
   console.log('B2B Checkout Settings')
   let checkVtex = null
@@ -147,10 +166,10 @@
     )
 
     const activeOptionText = activeOption
-      ? activeOption.innerText.trim().toLowerCase()
+      ? activeOption.dataset.name.toLowerCase()
       : ''
 
-    const isCreditCardActive = activeOptionText.indexOf('credit card') === 0
+    const isCreditCardActive = CREDIT_CARDS.includes(activeOptionText)
     let firstOption = null
 
     if (
@@ -159,9 +178,9 @@
       permissions.paymentTerms.length
     ) {
       allOptions.forEach(function (obj) {
-        const currOption = obj.innerText.trim().toLowerCase()
+        const currOption = obj.dataset.name.toLowerCase()
 
-        const isCreditCard = currOption.indexOf('credit card') === 0
+        const isCreditCard = CREDIT_CARDS.includes(currOption)
 
         if (
           permissions.paymentTerms.findIndex(function (pmt) {

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -231,7 +231,16 @@ const CREDIT_CARDS = [
     }
 
     // Show payment options available
-    showPaymentOptions(settings)
+    checkPayment = setInterval(function () {
+      if (
+        document.querySelectorAll(
+          '.orderform-template-holder #payment-data .payment-group-item'
+        ).length > 0
+      ) {
+        clearInterval(checkPayment)
+        showPaymentOptions(settings)
+      }
+    }, 500)
   }
 
   const applyMarketingData = function (organizationId, costCenterId) {
@@ -363,7 +372,7 @@ const CREDIT_CARDS = [
   checkQuotes()
   watchQuotes()
 
-  window.addEventListener('hashchange', function () {
+  const initialize = function () {
     const message = window.sessionStorage.getItem('message')
 
     if (settings.permissions) {
@@ -385,5 +394,7 @@ const CREDIT_CARDS = [
       })
       window.sessionStorage.removeItem('message')
     }
-  })
+  }
+
+  window.addEventListener('hashchange', initialize())
 })()

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -232,7 +232,7 @@ const CREDIT_CARDS = [
 
     // Show payment options available
     if (step.includes('payment')) {
-      checkPayment = setInterval(function () {
+      const checkPayment = setInterval(function () {
         if (
           document.querySelectorAll(
             '.orderform-template-holder #payment-data .payment-group-item'

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -72,7 +72,7 @@ export const resolvers = {
     settings: async (ctx: Context) => {
       const {
         clients: { graphQLServer, checkout, session, vbase },
-        vtex: { logger, storeUserAuthToken, production },
+        vtex: { host, logger, storeUserAuthToken, production },
       } = ctx
 
       const token: any = storeUserAuthToken
@@ -80,7 +80,7 @@ export const resolvers = {
       ctx.set('Content-Type', 'application/json')
       ctx.set('Cache-Control', 'no-cache, no-store')
 
-      if (!token) {
+      if (!token && !host?.includes('myvtex.com')) {
         ctx.response.body = {
           error: 'User not authenticated',
         }


### PR DESCRIPTION
Previously our checkout JS was comparing the "innerText" of each checkout payment method div against the payment methods assigned to the user's organization. However, in non-US stores, the innerText is likely a localized version of the payment method name and not the exact string that has been assigned to the organization. Therefore, this PR changes the matching logic to look at the div's `data-name` attribute where the original non-intl name is stored.

This PR also adjusts the checkout JS to ensure that the payment method logic runs after the payment method divs have been rendered.

It also allows the `b2bCheckoutSettings` to be returned if telemarketing impersonation is active and the original user is not logged in. It does this by only requiring the `storeUserAuthToken` if the host does not contain `myvtex.com`.

New version linked here: https://b2bsuite--sandboxusdev.myvtex.com 
and here: https://arthur--hermespardini.myvtex.com