### PR TITLE
[B2BCHCKOUT-22] Improve handling for impersonation expiration

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,11 @@ on:
       - chore/*
   pull_request:
     types: [opened, synchronize, reopened]
-    
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+  
 jobs:
   sonarcloud:
     name: SonarCloud

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- added an expiration time (5 minutes) for b2b-checkout-settings sessionStorage item 
+
+
 ## [1.2.0] - 2022-04-02
 
 ### Fixed

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -53,22 +53,18 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
     return window.__RUNTIME__.workspace !== 'master'
   }
 
-  const sessionStorageCheckout = window.sessionStorage.getItem(
-    'b2b-checkout-settings'
-  )
+  let settings =
+    JSON.parse(window.sessionStorage.getItem('b2b-checkout-settings')) ||
+    undefined
 
-  if (sessionStorageCheckout && sessionStorageCheckout.time) {
+  if (settings && settings.time) {
     const now = new Date().getTime()
-    const sessionStorageCheckoutTime = new Date(
-      sessionStorageCheckout.time
-    ).getTime()
+    const sessionStorageCheckoutTime = new Date(settings.time).getTime()
 
     if (now - sessionStorageCheckoutTime > MAX_TIME_EXPIRATION) {
       window.sessionStorage.removeItem('b2b-checkout-settings')
     }
   }
-
-  let settings = JSON.parse(sessionStorageCheckout) || undefined
 
   window.b2bCheckoutSettings = window.b2bCheckoutSettings || settings
 

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -20,6 +20,8 @@ const CREDIT_CARDS = [
   'credz',
 ]
 
+const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
+
 !(function () {
   console.log('B2B Checkout Settings')
   let checkVtex = null
@@ -51,9 +53,22 @@ const CREDIT_CARDS = [
     return window.__RUNTIME__.workspace !== 'master'
   }
 
-  let settings =
-    JSON.parse(window.sessionStorage.getItem('b2b-checkout-settings')) ||
-    undefined
+  const sessionStorageCheckout = window.sessionStorage.getItem(
+    'b2b-checkout-settings'
+  )
+
+  if (sessionStorageCheckout && sessionStorageCheckout.time) {
+    const now = new Date().getTime()
+    const sessionStorageCheckoutTime = new Date(
+      sessionStorageCheckout.time
+    ).getTime()
+
+    if (now - sessionStorageCheckoutTime > MAX_TIME_EXPIRATION) {
+      window.sessionStorage.removeItem('b2b-checkout-settings')
+    }
+  }
+
+  let settings = JSON.parse(sessionStorageCheckout) || undefined
 
   window.b2bCheckoutSettings = window.b2bCheckoutSettings || settings
 
@@ -350,6 +365,7 @@ const CREDIT_CARDS = [
         isWorkspace() ? `?v=${ts}` : ''
       }`,
     }).then(function (response) {
+      response.time = new Date().toISOString()
       window.sessionStorage.setItem(
         'b2b-checkout-settings',
         JSON.stringify(response)


### PR DESCRIPTION
#### What problem is this solving?

- The current use of sessionStorage for user impersonation needs to be improved;
- This is related to what Sofia was reporting this morning while testing telemarketing app impersonation;

### Solution

It was added a time expiration by 5 minutes to b2b-checkout-settings session storage key.

Before the checkout rendering, it checks if it exists and the time expiration and then removes the settings in order to renew by calling the API;

#### How to test it?

It's linked on: [https://b2borg--sandboxusdev.myvtex.com/](https://b2borg--sandboxusdev.myvtex.com/)

It's pretty hard to test once there is a flag preventing the tests:

```ts
      if (isWorkspace() || !settings) {
```
line: 378

To test it properly, I suggest you check out the branch in your own machine, remove the isWorkscape() function from the conditional statement, and then link and test it.

After that, you can show the time property on the sessionStorage and check after 5 minutes or change it manually to 5 minutes earlier.

