### PR TITLE
[B2BQUOTES-51] Ability to prevent a quote from being updated during checkout flow - Lock interface and can’t change quantity feature not working fine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug on checking impersonation email expiration
+
+
 ## [1.3.0] - 2022-04-15
 
 ### Added

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -65,7 +65,7 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
 
   if (storedSettings && storedSettings.time) {
     const now = new Date().getTime()
-    const sessionStorageCheckoutTime = new Date(settings.time).getTime()
+    const sessionStorageCheckoutTime = new Date(storedSettings.time).getTime()
 
     if (
       now - sessionStorageCheckoutTime < MAX_TIME_EXPIRATION &&


### PR DESCRIPTION
Fix a bug on checking impersonation email expiration

PR Related: [B2BCHCKOUT-22]
https://github.com/vtex-apps/b2b-checkout-settings/pull/22

### Problem

Ability to prevent a quote from being updated during checkout flow - Lock interface and can’t change quantity feature not working fine

### How to test

- Create quote/Open Existing quote
- Click Use quote button
- Then try to update product quantity

Actual Result: Able to update product quantity
Expected Result: Should not allow to update product quantity


### Solution

I found a bug related to the PR mentioned above, it was checking the email comparing the wrong variable, it was triggering an error and stopping the b2b checkout;

Workspace: [https://b2b1863508--productusqa.myvtex.com/](https://b2b1863508--productusqa.myvtex.com/)