### PR TITLE
[B2BORG-124] Fix bug getting b2b checkout settings info for logged in users in production domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bug returning `User not authenticated` error for logged in users when getting `b2b-checkout-settings` in production domains
+
 ## [1.3.3] - 2022-06-07
 
 ### Added

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -413,7 +413,7 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
     const ts = new Date().getTime()
 
     $.ajax({
-      url: `${rootPath}/b2b-checkout-settings/${
+      url: `${rootPath}/_v/private/b2b-checkout-settings/${
         isWorkspace() ? `?v=${ts}` : ''
       }`,
     }).then(function (response) {

--- a/node/service.json
+++ b/node/service.json
@@ -13,7 +13,7 @@
   "workers": 1,
   "routes": {
     "settings": {
-      "path": "/b2b-checkout-settings/",
+      "path": "/_v/private/b2b-checkout-settings/",
       "public": true
     }
   }


### PR DESCRIPTION
**What problem is this solving?**
In production (live domains), the endpoint `/b2b-checkout-settings/` returns `User not authenticated` even when the user is logged in. This does not happen in `myvtex` sites and may be caused by undefined `storeUserAuthToken`. I'm prefixing the route with `/_v/private` in order to use `storeUserAuthToken`.

**How to test it?**
I linked changes in workspace [anna](https://anna--marketplace3m.myvtex.com/) in account marketplace3m and tried to access the b2b checkout settings:

https://shop.metalinspec.com.mx/_v/private/b2b-checkout-settings?workspace=anna
<img width="1037" alt="Screen Shot 2022-06-29 at 1 54 41 PM copy" src="https://user-images.githubusercontent.com/53097865/176535777-8df0a3dc-ad3d-4dee-aa95-bde40513814c.png">

https://shop.metalinspec.com.mx/b2b-checkout-settings?workspace=master
<img width="649" alt="Screen Shot 2022-06-29 at 1 54 20 PM" src="https://user-images.githubusercontent.com/53097865/176535257-9e27084b-a62a-4e4a-890b-7339e7e8bc17.png">
