### PR TITLE
[B2BCHCKOUT-29] Allow non-B2B users to access checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow non-B2B users to access checkout when B2B Checkout Settings app is installed
+
 ## [1.4.1] - 2022-07-19
 
 ### Added

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -83,7 +83,7 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
       ? window.vtexjs.checkout.orderForm.clientProfileData.email
       : null
 
-  if (storedSettings && storedSettings.time && storedSettings.organizationId) {
+  if (storedSettings && storedSettings.time) {
     const now = new Date().getTime()
     const sessionStorageCheckoutTime = new Date(storedSettings.time).getTime()
 

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -83,7 +83,7 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
       ? window.vtexjs.checkout.orderForm.clientProfileData.email
       : null
 
-  if (storedSettings && storedSettings.time) {
+  if (storedSettings && storedSettings.time && storedSettings.organizationId) {
     const now = new Date().getTime()
     const sessionStorageCheckoutTime = new Date(storedSettings.time).getTime()
 
@@ -417,6 +417,12 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
         isWorkspace() ? `?v=${ts}` : ''
       }`,
     }).then(function (response) {
+      if (Object.keys(response).length === 0) {
+        window.sessionStorage.removeItem('b2b-checkout-settings')
+
+        return
+      }
+
       response.time = new Date().toISOString()
 
       if (

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -126,10 +126,18 @@ export default {
           })
         })
 
-      const settings = {
+      let settings = {
         ...DEFAULTS,
         ...accountSettings,
         ...checkUserPermission,
+      }
+
+      // allow users without organization or cost center to access checkout
+      if (
+        !userSession?.namespaces?.['storefront-permissions']?.organization ||
+        !userSession?.namespaces?.['storefront-permissions']?.costcenter
+      ) {
+        settings = {}
       }
 
       if (


### PR DESCRIPTION
#### What problem is this solving?

Currently non-B2B users don't have access to checkout when B2B Checkout Settings is installed. They don't have a role and so they don't have the permission `can-checkout` in their settings. This PR doesn't apply b2b settings for users who don't have an associated organization or cost center, allowing them to access the checkout.

#### How to test it?
Test in workspace [annab2bcheckout](https://annab2bcheckout--sandboxusdev.myvtex.com/).

In this workspace, I removed access to the checkout for users with Admin role. Add a new user with Admin access to any organization (e.g [this](https://annab2bcheckout--sandboxusdev.myvtex.com/admin/b2b-organizations/organizations/e9188242-e373-11ec-835d-0e08deb41249/#/users)). Go to store site > Login as B2B Organization Admin user > Add item to cart > Try to checkout > see access denied error. 

Repeat steps, creating a user _with_ access to the checkout (e.g. Sales Admin). This user should be able to access the checkout but _not_ edit Shipping.

Login as a non-B2B user or access checkout as guest. Checkout as normal, entering Profile, Shipping, and Payment info.

Call center operators will have the same access to checkout as the user they're impersonating.