### PR TITLE
[B2BCHCKOUT-29] Fix hidden shipping and payment CSS for non-B2B users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Show all Shipping and Payment sections for non-B2B users
+
 ## [1.4.2] - 2022-09-15
 
 ### Fixed

--- a/checkout-ui-custom/checkout6-custom.css
+++ b/checkout-ui-custom/checkout6-custom.css
@@ -21,16 +21,18 @@
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(0, 0, 0, 0.4);
 }
 
-.client-profile-data a.link-box-edit,
-button.vtex-omnishipping-1-x-buttonEditAddress,
-button.vtex-omnishipping-1-x-buttonCreateAddress,
-.orderform-template-holder #payment-data .payment-group-item {
+body.can-checkout .client-profile-data a.link-box-edit,
+body.can-checkout button.vtex-omnishipping-1-x-buttonEditAddress,
+body.can-checkout button.vtex-omnishipping-1-x-buttonCreateAddress,
+body.can-checkout .orderform-template-holder #payment-data .payment-group-item {
   display: none !important;
 }
+
 body.change-profile .client-profile-data a.link-box-edit,
 body.edit-shipping button.vtex-omnishipping-1-x-buttonEditAddress,
 body.add-shipping button.vtex-omnishipping-1-x-buttonCreateAddress,
-.orderform-template-holder
+body.can-checkout
+  .orderform-template-holder
   #payment-data
   .payment-group-item[data-b2b-allowed='true'] {
   display: block !important;

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -294,6 +294,8 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
   }
 
   const handleSettings = function () {
+    if (!settings) return
+
     if (settings.showPONumber === true) {
       buildPOField()
     }
@@ -458,7 +460,7 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
   const initialize = function () {
     const message = window.sessionStorage.getItem('message')
 
-    if (settings.permissions) {
+    if (settings && settings.permissions) {
       applyPermissions(settings.permissions)
     }
 


### PR DESCRIPTION
#### What problem is this solving?
Display profile editing option, all payment methods, and buttons to edit/add shipping addresses for non-B2B users.

#### How to test it?
Test in workspace [annab2bcheckout](https://annab2bcheckout--sandboxusdev.myvtex.com/).

Try checking out as a non-B2B user and you should be able to edit the Profile section, edit or add addresses in Shipping, and see all payment methods from the store in Payment.