### PR TITLE
fix(checkout6-custom): prevents TypeError from happening

### DIFF
--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -336,6 +336,10 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
           return item.id === 'b2b-quotes-graphql'
         })
 
+        const hasB2bQuote = index !== -1
+
+        if (!hasB2bQuote) return 
+
         const { quoteId } = customData.customApps[index].fields
 
         if (index !== -1 && quoteId && parseInt(quoteId, 10) !== 0) {


### PR DESCRIPTION
An error started to appear at checkout after I set a customData.

This code always gave an error because it didn't check if the b2b-quotes-graphql field existed in the find

with this pr I can check and if it does not exist it does not continue.



![image](https://user-images.githubusercontent.com/63638196/197050586-02bd4ab5-1253-464c-9b6d-9b4b56642c97.png)
![image](https://user-images.githubusercontent.com/63638196/197050661-4dc0b173-4595-4413-b157-af41d0266f23.png)
![image](https://user-images.githubusercontent.com/63638196/197050818-9e6bffae-9154-4edf-a0c5-dc3ba2a5608d.png)

