### PR TITLE
fix: :bug: insert semicolon at checkout-6-custom end

### DIFF
--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -478,4 +478,4 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
   }
 
   $(window).on('hashchange', () => initialize())
-})()
+})();


### PR DESCRIPTION
This PR is only to insert a semicolon at end of checkout6-custom.js.

Why: When we used b2b-checkout with checkout-ui-custom or with checkout-ui-settings the b2b code was breaking what comes after