### PR TITLE
Update roles in order to let user create address in checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add new configuration to let user create address in checkout
 
 ## [1.7.0] - 2023-04-26
 

--- a/vtex.storefront-permissions/configuration.json
+++ b/vtex.storefront-permissions/configuration.json
@@ -7,6 +7,18 @@
       "roles": ["store-admin", "sales-admin", "sales-manager"]
     },
     {
+      "label": "Can add shipping",
+      "value": "add-shipping",
+      "roles": [
+        "store-admin",
+        "sales-admin",
+        "sales-manager",
+        "sales-representative",
+        "customer-admin",
+        "customer-approver"
+      ]
+    },
+    {
       "label": "Can checkout",
       "value": "can-checkout",
       "roles": [


### PR DESCRIPTION
## Description: 
- Currently in the checkout we should allow users to be able to create a new address based on their roles

## Changes made:
- Allow users to create a new address if they have a specific role

## Where to test:
This can be tested [here](https://alberto--vysk.myvtex.com/)

**Steps to reproduce:**

1. Login using credentials: 
2. 
```
jose.basilio@vtex.com
Testing1234
```
3. Add a product to the cart
4. Proceed to shipping method
5. Edit address
6. This address should be saved when checking out 

## Screens
![Image 2023-05-09 at 5 21 40 p m](https://github.com/vtex-apps/b2b-checkout-settings/assets/11176519/cb20fffc-4089-4e6f-ae00-65c2eded9c90)
hot of changes:
