### PR TITLE
Feature/custom fields available b2b checkout settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Addded customFields to the b2bCheckoutSettings object
 
 ## [1.5.1] - 2023-04-17
 

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -220,6 +220,7 @@ export default {
                 getOrganizationById: {
                   paymentTerms: res?.data?.getOrganizationById?.paymentTerms,
                   status: res?.data?.getOrganizationById?.status,
+                  customFields: res?.data?.getOrganizationById?.customFields,
                 },
               },
             }
@@ -239,6 +240,10 @@ export default {
 
         if (!settings.paymentTerms && getOrganizationById?.paymentTerms) {
           settings.paymentTerms = getOrganizationById.paymentTerms
+        }
+
+        if (!settings.customFields && getOrganizationById?.customFields) {
+          settings.customFields = getOrganizationById.customFields
         }
 
         // if organization status is "on-hold" or "inactive", remove "can-checkout" permission

--- a/node/resolvers/Routes/queries.ts
+++ b/node/resolvers/Routes/queries.ts
@@ -16,6 +16,10 @@ export const QUERIES = {
         id
         name
       }
+      customFields {
+        name
+        value
+      }
     }
   }
   `,


### PR DESCRIPTION
## Description
- Users can now have access to the customFields set in their organization when checking out
- The B2B Checkout Settings object updated

## Changes made: 
- Modify query to also get Custom Fields

## Where to test: 
- You can test [here](https://alberto--cosmo.myvtex.com/)