### PR TITLE
Fix/b2b payment terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+- Remove validation after retrieving cost center information
+
 ## [1.9.0] - 2023-05-19
 
 ### Added

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -191,7 +191,6 @@ export default {
           settings.addresses = getCostCenterById.addresses
         }
 
-
         if (getCostCenterById?.customFields) {
           settings.costCenterCustomFields = getCostCenterById.customFields
         }

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -191,9 +191,6 @@ export default {
           settings.addresses = getCostCenterById.addresses
         }
 
-        if (getCostCenterById?.paymentTerms) {
-          settings.paymentTerms = getCostCenterById.paymentTerms
-        }
 
         if (getCostCenterById?.customFields) {
           settings.costCenterCustomFields = getCostCenterById.customFields


### PR DESCRIPTION
## Changes made:
Remove validation after retrieving costCenter information

## Reason for changes:
When retrieving the information, bring back as an empty string. So the information is there, but it's assigned as null. So this empty/null string value is assigned to the paymentTerms

#### Where to test?
https://alberto--helmethouseprod.myvtex.com/checkout/#/payment