### PR TITLE
Fix/change address b2c user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fix
+- Destroy checkout object if user is not logged in
+
 ## [1.9.2] - 2023-06-08
 
 ### Added

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -285,8 +285,8 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
       const canEditAddress = 'add-shipping'
       const checkShipping = setInterval(function () {
         if (
-          b2bCheckoutSettings &&
-          b2bCheckoutSettings.permissions.includes(canEditAddress) &&
+          (b2bCheckoutSettings &&
+            b2bCheckoutSettings.permissions.includes(canEditAddress)) ||
           !window.vtexjs.checkout.orderForm.loggedIn
         ) {
           clearInterval(checkShipping)

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -286,7 +286,8 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
       const checkShipping = setInterval(function () {
         if (
           b2bCheckoutSettings &&
-          b2bCheckoutSettings.permissions.includes(canEditAddress)
+          b2bCheckoutSettings.permissions.includes(canEditAddress) &&
+          window.vtexjs.checkout.orderForm.loggedIn == false
         ) {
           clearInterval(checkShipping)
           window.b2bCheckoutSettings = undefined

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -287,7 +287,7 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
         if (
           b2bCheckoutSettings &&
           b2bCheckoutSettings.permissions.includes(canEditAddress) &&
-          window.vtexjs.checkout.orderForm.loggedIn == false
+          window.vtexjs.checkout.orderForm.loggedIn === false
         ) {
           clearInterval(checkShipping)
           window.b2bCheckoutSettings = undefined

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -287,7 +287,7 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
         if (
           b2bCheckoutSettings &&
           b2bCheckoutSettings.permissions.includes(canEditAddress) &&
-          window.vtexjs.checkout.orderForm.loggedIn === false
+          !window.vtexjs.checkout.orderForm.loggedIn
         ) {
           clearInterval(checkShipping)
           window.b2bCheckoutSettings = undefined

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -283,11 +283,17 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
     }
     if (step.includes('shipping')) {
       const canEditAddress = 'add-shipping'
+      const isLoggedIn =
+        window.vtexjs &&
+        window.vtexjs.checkout &&
+        window.vtexjs.checkout.orderForm &&
+        window.vtexjs.checkout.orderForm.loggedIn
+
       const checkShipping = setInterval(function () {
         if (
+          !isLoggedIn ||
           (b2bCheckoutSettings &&
-            b2bCheckoutSettings.permissions.includes(canEditAddress)) ||
-          !window.vtexjs.checkout.orderForm.loggedIn
+            b2bCheckoutSettings.permissions.includes(canEditAddress))
         ) {
           clearInterval(checkShipping)
           window.b2bCheckoutSettings = undefined


### PR DESCRIPTION
#### Change made
Remove b2bCheckoutSettings Object if user is not logged in. 

#### Scenario:
User is not able to change address if they are checking out as a B2C user. 

#### Description:
Currently if the store has a b2c and b2b configuration it will bug on the change address, as the `omnishipping` only verifies that b2bCheckoutSetting exists, so this object can have an error or some message irrelevant to checking storeFront permissions. This blocks the user from changing their address. 

#### Testing: 
You can test this [here](https://alberto--cosmo.myvtex.com/)