### PR TITLE
Add b2bCheckoutSettings on payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.9.3] - 2023-06-12
 
 ### Fix
+- Set settings back in payment step if don't exist
+
+### Fix
 - Destroy checkout object if user is not logged in
 
 ## [1.9.2] - 2023-06-08

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -300,6 +300,9 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
         }
       }, 500)
     }
+    if (step.includes('payment') && b2bCheckoutSettings == undefined) {
+      b2bCheckoutSettings = settings
+    }
   }
 
   const applyMarketingData = function (organizationId, costCenterId) {


### PR DESCRIPTION
## Changes made:
- Add checkout settings to in the paymentStep if they do not exist.

## Description
When users have the change address added to their storeFront Permissions, the b2bCheckout settings object is removed. This not allowing paymentTerms settings for the organization not to render.

## Where to test:
You can test [here](https://albertoo--sandboxusdev.myvtex.com/checkout/#/payment)