### PR TITLE
Added semicolon to the checkout6 as it was causing an issue with build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fix
+### Fixed
 - Added semicolon to checkout ui custom
 
 ## [1.9.4] - 2023-06-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- Added semicolon to checkout ui custom
 
 ## [1.9.4] - 2023-06-28
 

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -503,4 +503,4 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
   }
 
   $(window).on('hashchange', () => initialize())
-})()
+})();


### PR DESCRIPTION
At the end of the checkout UI Custom js there was a semicolon missing that is causing issues with build.

