### PR TITLE
fix: adjust app name to get permission and token header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust sender app name and token to call check user permission
+
 ## [1.11.0] - 2023-11-30
 
 ### Added

--- a/node/clients/StorefrontPermissions.ts
+++ b/node/clients/StorefrontPermissions.ts
@@ -16,7 +16,7 @@ export default class StorefrontPermissions extends AppGraphQLClient {
         extensions: {
           persistedQuery: {
             provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-organizations@0.x',
+            sender: 'vtex.b2b-checkout-settings@1.x',
           },
         },
         query: QUERIES.getPermission,

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -26,8 +26,15 @@ export class Clients extends IOClients {
 }
 
 export const getTokenToHeader = (ctx: IOContext) => {
+  const token =
+    ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken
+
+  const { sessionToken } = ctx
+
   return {
-    VtexIdclientAutCookie:
-      ctx.storeUserAuthToken ?? ctx.adminUserAuthToken ?? ctx.authToken,
+    'x-vtex-credential': ctx.authToken,
+    VtexIdclientAutCookie: token,
+    cookie: `VtexIdclientAutCookie=${token}`,
+    'x-vtex-session': sessionToken,
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

We broker some B2B stores that have the app, because in the checkout page is showing the message "Acesso - Você não tem acesso ao checkout"

#### How to test it?

- Go to checkout page with some product and continue to payment

[Workspace](https://security--b2bsuite.myvtex.com/)
