### PR TITLE
fix: update payment terms cost center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Adjust payment terms on cost center
 
-## [1.11.2] - 2024-06-13
-
 ### Fixed
 
 - Add catalog-info.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Adjust payment terms on cost center
+
+## [1.11.2] - 2024-06-13
+
+### Fixed
+
 - Add catalog-info.yaml
 
 ## [1.11.1] - 2023-12-15

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.b2b-organizations",
   "version": "1.11.2",
   "dependencies": {
-    "@vtex/api": "6.46.0",
+    "@vtex/api": "6.46.1",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -224,9 +224,14 @@ export default {
             }
           })
 
-        if (!settings.paymentTerms && getOrganizationById?.paymentTerms) {
-          settings.paymentTerms = getOrganizationById.paymentTerms
-        }
+          if (settings.paymentTerms && getOrganizationById?.paymentTerms) {
+            const intersection = settings.paymentTerms.filter((obj: any) => getOrganizationById.paymentTerms.some((obj2: any) => obj.id === obj2.id && obj.name === obj2.name));
+            settings.paymentTerms = intersection
+          }
+
+          if (!settings.paymentTerms && getOrganizationById?.paymentTerms) {
+            settings.paymentTerms = getOrganizationById.paymentTerms
+          }
 
         if (!settings.customFields && getOrganizationById?.customFields) {
           settings.customFields = getOrganizationById.customFields

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -224,8 +224,9 @@ export default {
             }
           })
 
+          // fix to only show the payment terms that are in common between the organization and the cost center
           if (settings.paymentTerms && getOrganizationById?.paymentTerms) {
-            const intersection = settings.paymentTerms.filter((obj: any) => getOrganizationById.paymentTerms.some((obj2: any) => obj.id === obj2.id && obj.name === obj2.name));
+            const intersection = settings.paymentTerms.filter((ccPaymentTerms: any) => getOrganizationById.paymentTerms.some((orgPaymentTerms: any) => ccPaymentTerms.id === orgPaymentTerms.id && ccPaymentTerms.name === orgPaymentTerms.name));
             settings.paymentTerms = intersection
           }
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -857,10 +857,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.46.0":
-  version "6.46.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.0.tgz#208d14b96cbc8fd5eb6bd18fbd0c8424886e6154"
-  integrity sha512-XAvJlD1FG1GynhPXiMcayunahFCL2r3ilO5MHAWKxYvB/ljyxi4+U+rVpweeaQGpxHfhKHdfPe7qNEEh2oa2lw==
+"@vtex/api@6.46.1":
+  version "6.46.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.1.tgz#55a8755ae48f5400e7f1ed1921cd547950bb7a2a"
+  integrity sha512-geoxVvyWoQpOQ70Zmx3M8SBkRoGOS/bp9Gy26M+iCue63jofVSwmFz1zf66EaHA1PKOJNRgQPFwY+oeDE1U2lQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -3615,7 +3615,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?

Updating payment terms in the organization details UI does not apply to B2B checkout settings.

This behavior occurs because the update occurs only for the organization, but B2B checkout settings use cost center information, which is not updated by the organization details UI.

#### How to test it?

- Create an organization;
- In the organization details UI, update the payment terms;
- Access the website, assemble a cart and access checkout; Payment terms will remain the same.

[Workspace](https://giurigaud--b2bstore005.myvtex.com/checkout/#/cart)

#### Screenshots or example usage:

https://github.com/vtex-apps/b2b-checkout-settings/assets/62848434/46b0eb3c-a08b-4755-9cfe-8300e41d1c64

https://github.com/vtex-apps/b2b-checkout-settings/assets/62848434/b568a4f6-73cc-4571-8461-832c792dc279

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/RkCiFclgxbONkNTVb4/giphy.gif?cid=ecf05e477ln41uue0yzvyyym8ry69rkj2ocomdg0r7idtucg&ep=v1_gifs_related&rid=giphy.gif&ct=g)


