### PR TITLE
fix: Payment Terms changes not applied in the B2B Checkout Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.11.2] - 2024-06-12
-
 ### Fixed
 
 - Adjust payment terms on cost center
+
+## [1.11.2] - 2024-06-12
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Adjust payment terms on cost center
+
+### Fixed
+
 - Add catalog-info.yaml
 
 ## [1.11.1] - 2023-12-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Adjust payment terms on cost center
+
+### Fixed
+
 - Provide correct tokens to clients
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Adjust payment terms on cost center
-
-### Fixed
-
 - Add catalog-info.yaml
 
 ## [1.11.1] - 2023-12-15

--- a/node/package.json
+++ b/node/package.json
@@ -2,7 +2,7 @@
   "name": "vtex.b2b-organizations",
   "version": "1.11.2",
   "dependencies": {
-    "@vtex/api": "6.46.0",
+    "@vtex/api": "6.47.0",
     "atob": "^2.1.2",
     "co-body": "^6.0.0",
     "graphql": "^14.5.0",

--- a/node/resolvers/Routes/index.test.ts
+++ b/node/resolvers/Routes/index.test.ts
@@ -15,10 +15,47 @@ const getAddressMocked = jest.fn().mockResolvedValueOnce({
     getCostCenterById: {
       addresses: {},
       customFields: {},
-      paymentTerms: [{ id: costCenterPaymentTerms }],
+      paymentTerms: [
+        { id: costCenterPaymentTerms, name: costCenterPaymentTerms },
+      ],
     },
   },
 })
+
+const getOrganizationMocked = jest
+  .fn()
+  .mockImplementationOnce(() =>
+    Promise.resolve({
+      data: {
+        getOrganizationById: {
+          addresses: {},
+          customFields: {},
+          paymentTerms: [
+            {
+              id: costCenterPaymentTerms,
+              name: costCenterPaymentTerms,
+            },
+          ],
+        },
+      },
+    })
+  )
+  .mockImplementationOnce(() =>
+    Promise.resolve({
+      data: {
+        getOrganizationById: {
+          addresses: {},
+          customFields: {},
+          paymentTerms: [
+            {
+              id: organizationPaymentTerms,
+              name: organizationPaymentTerms,
+            },
+          ],
+        },
+      },
+    })
+  )
 
 const mockContext = () => {
   return {
@@ -28,15 +65,7 @@ const mockContext = () => {
       },
       organizations: {
         getAddresses: getAddressMocked,
-        getOrganization: jest.fn().mockResolvedValueOnce({
-          data: {
-            getOrganizationById: {
-              addresses: {},
-              customFields: {},
-              paymentTerms: [{ id: organizationPaymentTerms }],
-            },
-          },
-        }),
+        getOrganization: getOrganizationMocked,
       },
       session: {
         getSession: jest.fn().mockResolvedValueOnce({
@@ -80,6 +109,7 @@ describe('given Routes to call b2b checkout settings', () => {
       context = mockContext()
       await index.settings(context)
     })
+
     it('should return payments terms from cost center', () => {
       const { response } = context
 
@@ -97,6 +127,7 @@ describe('given Routes to call b2b checkout settings', () => {
       ).toBeFalsy()
     })
   })
+
   describe('when have just the organization with payment terms', () => {
     let context: Context
 
@@ -110,9 +141,11 @@ describe('given Routes to call b2b checkout settings', () => {
           },
         },
       })
+
       context = mockContext()
       await index.settings(context)
     })
+
     it('should return payments terms from organization', () => {
       const { response } = context
 

--- a/node/resolvers/Routes/index.ts
+++ b/node/resolvers/Routes/index.ts
@@ -1,3 +1,5 @@
+import type { PaymentTerm } from 'vtex.b2b-organizations-graphql'
+
 import { DEFAULTS, VBASE_BUCKET, VBASE_SETTINGS_FILE } from '../constants'
 
 const CACHE = 180
@@ -223,6 +225,20 @@ export default {
               },
             }
           })
+
+        // fix to only show the payment terms that are in common between the organization and the cost center
+        if (settings.paymentTerms && getOrganizationById?.paymentTerms) {
+          const intersection = settings.paymentTerms.filter(
+            (ccPaymentTerms: PaymentTerm) =>
+              getOrganizationById.paymentTerms.some(
+                (orgPaymentTerms: PaymentTerm) =>
+                  ccPaymentTerms.id === orgPaymentTerms.id &&
+                  ccPaymentTerms.name === orgPaymentTerms.name
+              )
+          )
+
+          settings.paymentTerms = intersection
+        }
 
         if (!settings.paymentTerms && getOrganizationById?.paymentTerms) {
           settings.paymentTerms = getOrganizationById.paymentTerms

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -857,10 +857,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@vtex/api@6.46.0":
-  version "6.46.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.46.0.tgz#208d14b96cbc8fd5eb6bd18fbd0c8424886e6154"
-  integrity sha512-XAvJlD1FG1GynhPXiMcayunahFCL2r3ilO5MHAWKxYvB/ljyxi4+U+rVpweeaQGpxHfhKHdfPe7qNEEh2oa2lw==
+"@vtex/api@6.47.0":
+  version "6.47.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
+  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -3615,7 +3615,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?
Updating payment terms in the organization details UI does not apply to B2B checkout settings.

This behavior occurs because the update occurs only for the organization, but B2B checkout settings use cost center information, which is not updated by the organization details UI.

#### How to test it?
* Create an organization;
* In the organization details UI, update the payment terms;
* Access the website, assemble a cart and access checkout; Payment terms will remain the same.

[Workspace](https://icaroov--b2bstore005.myvtex.com/checkout/#/cart)

#### How does this PR make you feel? [🔗](http://giphy.com/)

![](https://media.giphy.com/media/pYWyPf8dQWmGI/giphy.gif?cid=82a1493b24ilts1c52onkn5q377k5qhgm5ndxpok9e2zzrhx&ep=v1_gifs_trending&rid=giphy.gif&ct=g)
