### PR TITLE
Feat/checks if create quote permission is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Feat
 
-- Displays the create quota button according to the value of the create quota permission
+- Displays the create quota button according to the value of the create quota permission 
 
 ## [1.11.3] - 2024-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Feat
+
+- Displays the create quota button according to the value of the create quota permission
+
 ## [1.11.3] - 2024-07-15
 
 ### Fixed

--- a/checkout-ui-custom/checkout6-custom.js
+++ b/checkout-ui-custom/checkout6-custom.js
@@ -158,9 +158,8 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
     wrap.prepend(`
     <div class="b2b-purchase-order-number">
     <p class="b2b-purchase-order-number-label">
-    <label for="cart-b2b-purchase-order-number">${
-      getTranslation().cartPurchaseOrderLabel
-    }</label>
+    <label for="cart-b2b-purchase-order-number">${getTranslation().cartPurchaseOrderLabel
+      }</label>
     </p>
     <input class="input-small b2b-purchase-order-number-input" type="text" id="cart-b2b-purchase-order-number" value="${currValue}">
     </div>
@@ -189,7 +188,7 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
             app: 'b2b-quotes-graphql',
             field: 'quoteId',
           })
-          .then(function () {})
+          .then(function () { })
       })
     }
   }
@@ -317,6 +316,7 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
   }
 
   const handleSettings = function () {
+
     if (!settings) return
 
     if (settings.showPONumber === true) {
@@ -327,7 +327,11 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
       applyPermissions(settings.permissions)
     }
 
-    if (settings.showQuoteButton) {
+    const createQuotePermission = JSON.parse(
+      window.sessionStorage.getItem('checkout.createQuote')
+    )
+
+    if (settings.showQuoteButton && createQuotePermission) {
       buildCreateQuoteButton()
     }
 
@@ -440,9 +444,8 @@ const MAX_TIME_EXPIRATION = 1000 * 60 * 5 // 5 minutes
     const ts = new Date().getTime()
 
     $.ajax({
-      url: `${rootPath}/_v/private/b2b-checkout-settings/${
-        isWorkspace() ? `?v=${ts}` : ''
-      }`,
+      url: `${rootPath}/_v/private/b2b-checkout-settings/${isWorkspace() ? `?v=${ts}` : ''
+        }`,
     }).then(function (response) {
       if (Object.keys(response).length === 0) {
         window.sessionStorage.removeItem('b2b-checkout-settings')

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -3615,7 +3615,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What problem is this solving?
Before, it wasn't possible to get a create quote permission. Now the permission value is taken through session storage

<!--- What is the motivation and context for this change? -->
The create quote button does not appear at checkout if the logged in user does not have permission

#### How to test it?
1. Go to [https://giubernal--b2bstore005.myvtex.com/](https://giubernal--b2bstore005.myvtex.com/)
2. Do the login
3. Add a new product
4. Open the mini cart
5. After then click on the button: Ir para o checkout

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[https://giubernal--b2bstore005.myvtex.com/](https://giubernal--b2bstore005.myvtex.com/)

#### Screenshots or example usage:
<img width="1439" alt="Screenshot 2024-09-09 at 11 45 19" src="https://github.com/user-attachments/assets/5a3d845e-d083-4344-b7ae-c31c8e8d78b5">

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
