### PR TITLE
chore: update dependency major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update dependency major version
+
 ## [1.12.3] - 2024-10-10
 
 ## [1.12.2] - 2024-10-10

--- a/manifest.json
+++ b/manifest.json
@@ -12,12 +12,12 @@
     "messages": "1.x",
     "node": "6.x",
     "react": "3.x",
-    "vtex.storefront-permissions": "1.x"
+    "vtex.storefront-permissions": "2.x"
   },
   "dependencies": {
     "vtex.graphql-server": "1.x",
     "vtex.styleguide": "9.x",
-    "vtex.b2b-organizations-graphql": "0.x"
+    "vtex.b2b-organizations-graphql": "1.x"
   },
   "scripts": {
     "prereleasy": "bash lint.sh"

--- a/node/clients/Organizations.ts
+++ b/node/clients/Organizations.ts
@@ -7,7 +7,7 @@ import { getTokenToHeader } from './index'
 
 export class OrganizationsGraphQLClient extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super('vtex.b2b-organizations-graphql@0.x', ctx, options)
+    super('vtex.b2b-organizations-graphql@1.x', ctx, options)
   }
 
   public getAddresses = async (costCenterId: string): Promise<any> => {
@@ -15,8 +15,8 @@ export class OrganizationsGraphQLClient extends AppGraphQLClient {
       {
         extensions: {
           persistedQuery: {
-            provider: 'vtex.b2b-organizations-graphql@0.x',
-            sender: 'vtex.b2b-checkout-settings@1.x',
+            provider: 'vtex.b2b-organizations-graphql@1.x',
+            sender: 'vtex.b2b-checkout-settings@2.x',
           },
         },
         query: QUERIES.getAddresses,
@@ -38,8 +38,8 @@ export class OrganizationsGraphQLClient extends AppGraphQLClient {
       {
         extensions: {
           persistedQuery: {
-            provider: 'vtex.b2b-organizations-graphql@0.x',
-            sender: 'vtex.b2b-checkout-settings@1.x',
+            provider: 'vtex.b2b-organizations-graphql@1.x',
+            sender: 'vtex.b2b-checkout-settings@2.x',
           },
         },
         query: QUERIES.getOrganizationDetails,

--- a/node/clients/StorefrontPermissions.ts
+++ b/node/clients/StorefrontPermissions.ts
@@ -7,7 +7,7 @@ import { getTokenToHeader } from './index'
 
 export default class StorefrontPermissions extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super('vtex.storefront-permissions@1.x', ctx, options)
+    super('vtex.storefront-permissions@2.x', ctx, options)
   }
 
   public checkUserPermission = async (): Promise<any> => {
@@ -15,8 +15,8 @@ export default class StorefrontPermissions extends AppGraphQLClient {
       {
         extensions: {
           persistedQuery: {
-            provider: 'vtex.storefront-permissions@1.x',
-            sender: 'vtex.b2b-checkout-settings@1.x',
+            provider: 'vtex.storefront-permissions@2.x',
+            sender: 'vtex.b2b-checkout-settings@2.x',
           },
         },
         query: QUERIES.getPermission,


### PR DESCRIPTION
**What problem is this solving?**

Update major dependencies.

**How should this be manually tested?**

The new major versions for the following apps must be installed in other to test (which can be done only after all PRs updating versions are merged):
```
vtex.b2b-organizations-graphql@1.x
vtex.b2b-quotes-graphql@3.x
vtex.storefront-permissions@2.x
vtex.storefront-permissions-ui@2.x
vtex.storefront-permissions-components@1.x
vtex.b2b-quotes@2.x
vtex.b2b-organizations@2.x
vtex.b2b-checkout-settings@2.x
vtex.b2b-admin-customers@1.x
vtex.b2b-theme@4.x
vtex.b2b-orders-history@1.x
vtex.b2b-my-account@1.x
vtex.b2b-suite@1.x
```