### PR TITLE
chore: major update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update dependency major version. If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
+    - vtex.b2b-admin-customers@2.x
+    - vtex.b2b-checkout-settings@3.x
+    - vtex.b2b-my-account@2.x
+    - vtex.b2b-orders-history@2.x
+    - vtex.b2b-organizations@3.x
+    - vtex.b2b-organizations-graphql@2.x
+    - vtex.b2b-quotes@3.x
+    - vtex.b2b-quotes-graphql@4.x
+    - vtex.b2b-suite@2.x
+    - vtex.b2b-theme@5.x
+    - vtex.storefront-permissions-components@2.x
+    - vtex.storefront-permissions-ui@1.x
+
 ## [2.0.0] - 2025-05-27
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -12,12 +12,12 @@
     "messages": "1.x",
     "node": "6.x",
     "react": "3.x",
-    "vtex.storefront-permissions": "2.x"
+    "vtex.storefront-permissions": "3.x"
   },
   "dependencies": {
     "vtex.graphql-server": "1.x",
     "vtex.styleguide": "9.x",
-    "vtex.b2b-organizations-graphql": "1.x"
+    "vtex.b2b-organizations-graphql": "2.x"
   },
   "scripts": {
     "prereleasy": "bash lint.sh"

--- a/node/clients/Organizations.ts
+++ b/node/clients/Organizations.ts
@@ -7,7 +7,7 @@ import { getTokenToHeader } from './index'
 
 export class OrganizationsGraphQLClient extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super('vtex.b2b-organizations-graphql@1.x', ctx, options)
+    super('vtex.b2b-organizations-graphql@2.x', ctx, options)
   }
 
   public getAddresses = async (costCenterId: string): Promise<any> => {
@@ -15,8 +15,8 @@ export class OrganizationsGraphQLClient extends AppGraphQLClient {
       {
         extensions: {
           persistedQuery: {
-            provider: 'vtex.b2b-organizations-graphql@1.x',
-            sender: 'vtex.b2b-checkout-settings@2.x',
+            provider: 'vtex.b2b-organizations-graphql@2.x',
+            sender: 'vtex.b2b-checkout-settings@3.x',
           },
         },
         query: QUERIES.getAddresses,
@@ -38,8 +38,8 @@ export class OrganizationsGraphQLClient extends AppGraphQLClient {
       {
         extensions: {
           persistedQuery: {
-            provider: 'vtex.b2b-organizations-graphql@1.x',
-            sender: 'vtex.b2b-checkout-settings@2.x',
+            provider: 'vtex.b2b-organizations-graphql@2.x',
+            sender: 'vtex.b2b-checkout-settings@3.x',
           },
         },
         query: QUERIES.getOrganizationDetails,

--- a/node/clients/StorefrontPermissions.ts
+++ b/node/clients/StorefrontPermissions.ts
@@ -7,7 +7,7 @@ import { getTokenToHeader } from './index'
 
 export default class StorefrontPermissions extends AppGraphQLClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
-    super('vtex.storefront-permissions@2.x', ctx, options)
+    super('vtex.storefront-permissions@3.x', ctx, options)
   }
 
   public checkUserPermission = async (): Promise<any> => {
@@ -15,8 +15,8 @@ export default class StorefrontPermissions extends AppGraphQLClient {
       {
         extensions: {
           persistedQuery: {
-            provider: 'vtex.storefront-permissions@2.x',
-            sender: 'vtex.b2b-checkout-settings@2.x',
+            provider: 'vtex.storefront-permissions@3.x',
+            sender: 'vtex.b2b-checkout-settings@3.x',
           },
         },
         query: QUERIES.getPermission,


### PR DESCRIPTION
**What problem is this solving?**

Generating new major version. This new version includes ACL feature. Now the following permissions are needed to view/edit organizations within the admin UI app:
`Buyer Organizations / buyer_organization_view`
`Buyer Organizations / buyer_organization_edit`

If you are updating to this major version, make sure to update the following apps (if you have then installed) to the following major versions:
    - vtex.b2b-admin-customers@2.x
    - vtex.b2b-checkout-settings@3.x
    - vtex.b2b-my-account@2.x
    - vtex.b2b-orders-history@2.x
    - vtex.b2b-organizations@3.x
    - vtex.b2b-organizations-graphql@2.x
    - vtex.b2b-quotes@3.x
    - vtex.b2b-quotes-graphql@4.x
    - vtex.b2b-suite@2.x
    - vtex.b2b-theme@5.x
    - vtex.storefront-permissions-components@2.x
    - vtex.storefront-permissions-ui@1.x